### PR TITLE
Use a combination of event throttling and raf looping to improve perf…

### DIFF
--- a/packages/backend-touch/package.json
+++ b/packages/backend-touch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pspdfkit-labs/react-dnd-touch-backend",
-  "version": "11.1.8",
+  "version": "11.1.9",
   "description": "Touch backend for react-dnd",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
During testing of our SDK it appears that some browsers can emit screen tearing on lower end devices. Potentially this is due to slow event handling during screen renders.

During profiling I found some event handlers could take as much as 3 seconds to fire on a VM with very low memory and low core counts. Which goes over our frame budget.

I've tried the following techniques which seem to result in event handlers taking 20 - 50ms to fire which should allow for more timely updates during repaints.

We now:

- We throttle mouse/touch events to only handle them every 50 milliseconds as most move updates only translate to a very minor move.

- Instead of requesting an animation update on every move we start an animation frame update loop when we detect the first move which means we will get regular frame updates when the browser is ready to handle them.


I also attempted to make all event handlers passive but it appears in a few places events are cancelled. Potentially this is another optimisation that can be done if needed.