### PR TITLE
Workaround for shadow root to work with TouchBackend

### DIFF
--- a/packages/backend-touch/src/OptionsReader.ts
+++ b/packages/backend-touch/src/OptionsReader.ts
@@ -15,6 +15,7 @@ export class OptionsReader implements TouchBackendOptions {
 	public scrollAngleRanges: AngleRange[] | undefined = undefined
 	public delayTouchStart: number
 	public delayMouseStart: number
+	public isShadowRoot = false
 	public getDropTargetElementsAtPoint?: (
 		x: number,
 		y: number,


### PR DESCRIPTION
See https://github.com/react-dnd/react-dnd/issues/3449 for more details.

The added logic for `getDropTargetElementsAtPoint` will trigger it on `hover,` so we use `getDropTargetElementsAtPoint` on the client side to have the same logic as hover. 